### PR TITLE
Stop screens as well as localStreams on `stop`

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,22 +85,34 @@ LocalMedia.prototype.stop = function (stream) {
     // FIXME: duplicates cleanup code until fixed in FF
     if (stream) {
         stream.stop();
-        self.emit('localStreamStopped', stream);
         var idx = self.localStreams.indexOf(stream);
         if (idx > -1) {
+            self.emit('localStreamStopped', stream);
             self.localStreams = self.localStreams.splice(idx, 1);
+        } else {
+            idx = self.localScreens.indexOf(stream);
+            if (idx > -1) {
+                self.emit('localScreenStopped', stream);
+                self.localScreens = self.localScreens.splce(idx, 1);
+            }
         }
     } else {
-        if (this.audioMonitor) {
-            this.audioMonitor.stop();
-            delete this.audioMonitor;
-        }
-        this.localStreams.forEach(function (stream) {
-            stream.stop();
-            self.emit('localStreamStopped', stream);
-        });
-        this.localStreams = [];
+        this.stopStreams();
+        this.stopScreenShare();
     }
+};
+
+LocalMedia.prototype.stopStreams = function () {
+    var self = this;
+    if (this.audioMonitor) {
+        this.audioMonitor.stop();
+        delete this.audioMonitor;
+    }
+    this.localStreams.forEach(function (stream) {
+        stream.stop();
+        self.emit('localStreamStopped', stream);
+    });
+    this.localStreams = [];
 };
 
 LocalMedia.prototype.startScreenShare = function (cb) {
@@ -130,11 +142,14 @@ LocalMedia.prototype.startScreenShare = function (cb) {
 };
 
 LocalMedia.prototype.stopScreenShare = function (stream) {
+    var self = this;
     if (stream) {
         stream.stop();
+        this.emit('localScreenStopped', stream);
     } else {
         this.localScreens.forEach(function (stream) {
             stream.stop();
+            self.emit('localScreenStopped', stream);
         });
         this.localScreens = [];
     }


### PR DESCRIPTION
- Stop screens when `stop` is called; 
- emit correct event if `stop` is called with a stream (might be a screen stream)
- ensure stop events are emitted consistently when streams are stopped
- break stopping of all local streams out into `stopStreams`