### PR TITLE
Upgrade getscreenmedia

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "localmedia",
-  "version": "4.0.2",
+  "version": "5.0.0",
   "license": "ISC",
   "homepage": "https://github.com/otalk/localmedia#readme",
   "bugs": {
@@ -19,19 +19,19 @@
   "description": "WebRTC abstraction for managing local media streams.",
   "dependencies": {
     "wildemitter": "^1.0.0",
-    "getscreenmedia": "^4.0.0",
+    "getscreenmedia": "^5.0.0",
     "hark": "^1.0.0",
     "mockconsole": "0.0.x"
   },
   "devDependencies": {
     "browserify": "^13.1.0",
-    "jshint": "^2.9.2",
+    "jshint": "^2.9.5",
     "precommit-hook": "^3.0.0",
     "tape": "^4.6.0",
-    "webrtc-adapter": "^3.1.6"
+    "webrtc-adapter": "^6.0.0"
   },
   "peerDependencies": {
-    "webrtc-adapter": "^3.1.6"
+    "webrtc-adapter": "^6.0.0"
   },
   "testling": {
     "files": "test/*.js"


### PR DESCRIPTION
Maintenance. Noticed we're still getting a rogue adapter.js pulled in because getscreenmedia 4 still pulls it in.